### PR TITLE
バナーのダウンロード方法を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 <h3>バナー</h3>
 <img src="banner_small.png" alt="おつかれベイビーズのバナー88×31px" style="border:1px solid #000;">
 <img src="banner.png" alt="おつかれベイビーズのバナー200×40px" style="border:1px solid #000;">
-<p><smail><font color="red">※直リン禁止！</font></smail></p>
+<p>バナーは右クリック→「名前を付けて画像を保存」して、ダウンロードして使ってください。<smail><font color="red">※直リン禁止！</font></smail></p>
 
 <h2><a href="https://github.com/otsukare-babys/otsukare-babys.github.io">プルリク待ってます！！！！</a></h2>
 


### PR DESCRIPTION
現在、バナーの部分には「※直リン禁止！」という謎の一言のみが記載されています。
リンクをしたい人がバナーをどのように扱うべきか記載が無いため、ブラウザ(Chrome)からダウンロードする文言を追加します。