### PR TITLE
直リン禁止のマークアップを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 <h3>バナー</h3>
 <img src="banner_small.png" alt="おつかれベイビーズのバナー88×31px" style="border:1px solid #000;">
 <img src="banner.png" alt="おつかれベイビーズのバナー200×40px" style="border:1px solid #000;">
-<p>バナーは右クリック→「名前を付けて画像を保存」して、ダウンロードして使ってください。<smail><font color="red">※直リン禁止！</font></smail></p>
+<p>バナーは右クリック→「名前を付けて画像を保存」して、ダウンロードして使ってください。<small style="color: red;">※直リン禁止！</small></p>
 
 <h2><a href="https://github.com/otsukare-babys/otsukare-babys.github.io">プルリク待ってます！！！！</a></h2>
 


### PR DESCRIPTION
[`<small>` タグ](https://developer.mozilla.org/ja/docs/Web/HTML/Element/small)をtypoしているように見えたので修正しました。副作用として、「※直リン禁止！」の文言が変更前に比べてやや小さくなっています。

また、[`<font>` タグはHTML5で廃止されている](https://developer.mozilla.org/ja/docs/Web/HTML/Element/font)ので、`<small>` タグに等価なスタイルをあてるようにしました。